### PR TITLE
ESP32 port

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,9 @@ To get nice graphs out of it, check my [Metergrafiekjes docker configuration]!
 
 ## Compatibility & Hardware
 
-Written for and tested on Wemos D1 mini v2, should work on any ESP8266 derived device.
+Written for and tested on Wemos S2 mini, might work on any ESP32 derived device.
+
+For ESP8266 support, look at older versions. But larger telegrams may not fit in the smaller buffer.
 
 The RTS needs 5V input to be triggered. This means that if you use an ESP or other
 microcontroller that works on 3.3V, you will need a level shifter or an RTL inverter

--- a/platformio.ini
+++ b/platformio.ini
@@ -12,8 +12,8 @@
 src_dir = .
 
 [env:default]
-platform = espressif8266
-board = d1_mini
+platform = espressif32
+board = lolin_s2_mini
 framework = arduino
 monitor_speed = 115200
 upload_speed = 921600

--- a/settings.example.h
+++ b/settings.example.h
@@ -35,7 +35,7 @@ const char* client_id  = "Metertrekker";
   #define RTS_LOW LOW
 #endif
 
-#define RTS_PIN D3
+#define RTS_PIN 18
 
 /* Rx pin for SoftwareSerial */
 #define RX_PIN RX


### PR DESCRIPTION
Basically, I found out that we actually had boards that are mechanically and electrically compatible (if you ignore half the pins) and doing all the other stuff suddenly became trivial.

So:
 - ported the project from `ESP8266` / `Wemos D1 mini` to `ESP32` / `Wemos S2 mini`
 - set buffers to 4096 bytes
 - added wifi timeout in addition to telegram timeout (untested so far)
 - changed `LittleFS` -> `SPIFFS` (required for wifisettings on esp32)
 - changed readme and settings.example.h to reflect the Wemos S2 mini

I'll report on wifi reliability and wifi timeout stuff later this week if I don't forget.

Memory stats:
```
Before (esp8266):
RAM:   [====      ]  44.2% (used 36220 bytes from 81920 bytes)
Flash: [====      ]  37.8% (used 394904 bytes from 1044464 bytes)

After (esp32):
RAM:   [==        ]  18.5% (used 60532 bytes from 327680 bytes)
Flash: [======    ]  64.5% (used 845090 bytes from 1310720 bytes)
```

For reference, the board I was using (left) and the board I'm using now (right):
![PXL_20250219_062711070](https://github.com/user-attachments/assets/c4e0575c-4ae8-4bdf-85d0-5d2ee26a2642)
![PXL_20250219_062657297](https://github.com/user-attachments/assets/c6f634d2-4c3d-4e7f-b110-6427666bb9bf)
